### PR TITLE
Pass-through options to HTTParty to support :body, :headers, etc

### DIFF
--- a/lib/restparty.rb
+++ b/lib/restparty.rb
@@ -32,7 +32,7 @@ class RestParty
     def build_delete
       class_eval %{
         def self.delete(id, options = {})
-          delete('/#{@resource}/'+id.to_s, :query => options)
+          delete('/#{@resource}/'+id.to_s, options)
         end
       }
     end
@@ -40,7 +40,7 @@ class RestParty
     def build_update
       class_eval %{
         def self.update(id, options = {})
-          put('/#{@resource}/'+id.to_s, :query => options, :headers => {'Content-Length' => '0'})
+          put('/#{@resource}/'+id.to_s, options)
         end
       }
     end
@@ -50,9 +50,9 @@ class RestParty
         def self.find(id, options = {})
           response = ""
           if id.to_s == "all" and #{@resource_methods.include?(:index)}
-            response = get('/#{@resource}', :query => options)
+            response = get('/#{@resource}', options)
           elsif #{@resource_methods.include?(:show)}
-            response = get('/#{@resource}/'+id.to_s, :query => options)
+            response = get('/#{@resource}/'+id.to_s, options)
           else
             raise ArgumentError, "only :all, 'all' or integer values are supported"
           end
@@ -63,7 +63,7 @@ class RestParty
     def build_create
       class_eval %{
         def self.create(options = {})
-          post('/#{@resource}', :query => options)
+          post('/#{@resource}', options)
         end
       }
     end
@@ -73,7 +73,7 @@ class RestParty
         raise 'error_http_method' unless valid_http_method?(method)
         class_eval %{
           def self.#{collection}(options = {})
-          #{method}('/#{@resource}/#{collection}', :query => options)
+          #{method}('/#{@resource}/#{collection}', options)
           end
         }
       end
@@ -84,7 +84,7 @@ class RestParty
         raise 'error_method' unless valid_http_method?(method)
         class_eval %{
           def self.#{member}(id, options = {})
-          #{method}('/#{@resource}/'+id.to_s+'/#{member}', :query => options)
+          #{method}('/#{@resource}/'+id.to_s+'/#{member}', options)
           end
         }
       end


### PR DESCRIPTION
The current version assumes the POST/PUT data will be appended to the query-string and doesn't provide nearly the functionality of the underlying HTTParty does. This change just passes options straight through so you can use any of the available HTTParty options, such as :body, :headers, :*_proxy, :limit, etc. The use case that drove me to this change is for JSON/XML support in the body of the message. 

Since this breaks backwards compatibility, I understand if you don't want to incorporate this changeset. However, I do think there's much to be gained from it. (Like full power of HTTParty :)

-Cody
